### PR TITLE
Fix Kings / Faust Autosplitting

### DIFF
--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -1,4 +1,5 @@
-// Version: 1.0.3
+// Version: 1.0.4
+
 // By NitrogenCynic (https://www.speedrun.com/users/NitrogenCynic) and Hilimii (https://www.speedrun.com/users/Hilimii)
 state("ProjectWingman-Win64-Shipping")
 {

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -25,7 +25,7 @@ state("ProjectWingman-Win64-Shipping")
         // 9 = Debrief
         // 10 = PostDebriefCutscene
     byte onMissionSequence: "ProjectWingman-Win64-Shipping.exe", 0x9150ED0, 0x0, 0x180, 0x99B; // On Mission Sequence - True while in a 'Mission Sequence'
-        // Triggers after a difficulty has been selected, once the player transitions from LevelSequencePhase 0 to 1 (Briefing)
+    // Triggers after a difficulty has been selected, once the player transitions from LevelSequencePhase 0 to 1 (Briefing)
     byte onFreeMission: "ProjectWingman-Win64-Shipping.exe", 0x9150ED0, 0x0, 0x180, 0x99A; // On Free Mission - True when in a free mission - Applicable to ILs
     byte controllerPawn: "ProjectWingman-Win64-Shipping.exe", 0x95AC140, 0x30, 0x250; // Reference to the WingmanPlayerController.Pawn
 }

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -88,6 +88,8 @@ start
 
 init{
 
+
+// TODO: Find a reliable way to read mission names, so we can error trap these functions.
 // Returns True when the mission Kings in the main campaign is complete.
 // Rules consider this to be completion of the fadeout after Crimson 1.
 vars.KingsSplit = (Func<bool>)(()=>

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -120,11 +120,20 @@ init
     // Rules consider this to be when the Frontline 59 logo cutscene starts.
     vars.FaustSplit = (Func<bool>)(() =>
         {
+            var gameBase = modules.First().BaseAddress;
+            print("Game Base: " + gameBase.ToString("X"));
+            var expectedOffset = 0x8550; // Extracted from the MF59Ending address pattern
+
             var controllerPawnPtr = new DeepPointer("ProjectWingman-Win64-Shipping.exe", 0x95AC140, 0x30, 0x250);
             var pawnClassPtr = controllerPawnPtr.Deref<IntPtr>(game);
             var pawnClass = game.ReadPointer(pawnClassPtr);
             print("Pawn Class: " + pawnClass.ToString("X"));
-            return (pawnClass.ToString("X") == "7FF717B68550"); // During the logo cutscene, the WingmanPlayerController.Pawn is swapped from a FlyingPawn to a MF59Ending pawn
+
+            var relativeOffset = (long)pawnClass - (long)gameBase;
+            print("Relative Offset: " + relativeOffset.ToString("X"));
+
+            // Check that the relative offset ends with 8550
+            return (relativeOffset & 0xFFFF) == expectedOffset;
         }
     );
 

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -83,7 +83,7 @@ start
 {
     vars.beatKings = false;
     vars.beatFaust = false;
-    
+
     // Mission mode only
     // Start the timer when playerRef transitions from undefined (menu) to defined (in mission)
     return
@@ -129,16 +129,16 @@ init
     vars.FaustSplit = (Func<bool>)(() =>
         {
             var gameBase = modules.First().BaseAddress;
-            print("Game Base: " + gameBase.ToString("X"));
             var expectedOffset = 0x8550; // Extracted from the MF59Ending address pattern
 
             var controllerPawnPtr = new DeepPointer("ProjectWingman-Win64-Shipping.exe", 0x95AC140, 0x30, 0x250);
             var pawnClassPtr = controllerPawnPtr.Deref<IntPtr>(game);
             var pawnClass = game.ReadPointer(pawnClassPtr);
-            print("Pawn Class: " + pawnClass.ToString("X"));
 
             var relativeOffset = (long)pawnClass - (long)gameBase;
-            print("Relative Offset: " + relativeOffset.ToString("X"));
+
+            // Debug in case this ever breaks
+            // print("Relative Offset: " + relativeOffset.ToString("X"));
 
             // Check that the relative offset ends with 8550
             if ((relativeOffset & 0xFFFF) == expectedOffset)

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -55,6 +55,7 @@ reset
 {
     // Reset timer when playerRef is dereferenced (goes from defined to undefined).
     // Mission mode only.
+    // Consider using the LoadingManager.IntoLevel property. 1 when in loading, 0 when not.
     return (current.playerRef == 0 && old.playerRef != 0 && settings["Mission"] == true);
 }
 
@@ -87,7 +88,6 @@ start
 
 init
 {
-    // TODO: Find a reliable way to read mission names, so we can error trap these functions.
     // Returns True when the mission Kings in the main campaign is complete.
     // Rules consider this to be completion of the fadeout after Crimson 1.
     vars.KingsSplit = (Func<byte, byte, byte, bool>)((currPhase, oldPhase, missionComplete) =>

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -81,6 +81,9 @@ reset
 
 start
 {
+    vars.beatKings = false;
+    vars.beatFaust = false;
+    
     // Mission mode only
     // Start the timer when playerRef transitions from undefined (menu) to defined (in mission)
     return
@@ -112,7 +115,12 @@ init
     // Rules consider this to be completion of the fadeout after Crimson 1.
     vars.KingsSplit = (Func<byte, byte, byte, bool>)((currPhase, oldPhase, missionComplete) =>
         {
-            return  currPhase == 7 && oldPhase == 6 && missionComplete == 2;
+            if (currPhase == 7 && oldPhase == 6 && missionComplete == 2)
+            {
+                vars.beatKings = true;
+                return true;
+            };
+            return false;
         }
     );
 
@@ -133,7 +141,12 @@ init
             print("Relative Offset: " + relativeOffset.ToString("X"));
 
             // Check that the relative offset ends with 8550
-            return (relativeOffset & 0xFFFF) == expectedOffset;
+            if ((relativeOffset & 0xFFFF) == expectedOffset)
+            {
+                vars.beatFaust = true;
+                return true;
+            };
+            return false;
         }
     );
 
@@ -153,10 +166,10 @@ init
 split
 {
     // Trigger a split when missionComplete transitions from 2 to 3 (for most missions) or at the end of Kings or Faust.
-    if (vars.GetLevelID() == "mf_06"){
+    if (vars.GetLevelID() == "mf_06" && !vars.beatFaust){
          return vars.FaustSplit();
         }
-    else if (vars.GetLevelID() == "campaign_22"){
+    else if (vars.GetLevelID() == "campaign_22" && !vars.beatKings){
         return vars.KingsSplit(current.levelSequencePhase, old.levelSequencePhase, current.missionComplete);
     }
     else{

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -86,36 +86,39 @@ start
     );
 }
 
-init{
+init
+{
+    // TODO: Find a reliable way to read mission names, so we can error trap these functions.
+    // Returns True when the mission Kings in the main campaign is complete.
+    // Rules consider this to be completion of the fadeout after Crimson 1.
+    vars.KingsSplit = (Func<byte, byte, byte, bool>)((currPhase, oldPhase, missionComplete)=>
+        {
+            return  currPhase == 7 && oldPhase == 6 && missionComplete == 2;
+        }
+    );
 
-
-// TODO: Find a reliable way to read mission names, so we can error trap these functions.
-// Returns True when the mission Kings in the main campaign is complete.
-// Rules consider this to be completion of the fadeout after Crimson 1.
-vars.KingsSplit = (Func<bool>)(()=>
-    {
-        return  current.levelSequencePhase == 7 && old.levelSequencePhase == 6 && current.missionComplete == 2;
-    }
-);
-
-// Returns True when the mission Faust in Frontline 59 is complete.
-// Rules consider this to be when the Frontline 59 logo cutscene starts.
-vars.FaustSplit = (Func<bool>)(() =>
-    {
-        return (
-            current.levelSequencePhase == 6 &&
-            current.missionComplete != 3 &&
-            current.playerRef != 0 &&
-            (current.controllerPawn != current.playerRef) // During the logo cutscene, the WingmanPlayerController.Pawn is swapped from a FlyingPawn to a MF59Ending pawn
-        );
-    }
-);
+    // Returns True when the mission Faust in Frontline 59 is complete.
+    // Rules consider this to be when the Frontline 59 logo cutscene starts.
+    vars.FaustSplit = (Func<byte, byte, byte, byte, bool>)((currPhase, missionComplete, playerRef, controllerPawn) =>
+        {
+            return (
+                current.levelSequencePhase == 6 &&
+                current.missionComplete != 3 &&
+                current.playerRef != 0 &&
+                (current.controllerPawn != current.playerRef) // During the logo cutscene, the WingmanPlayerController.Pawn is swapped from a FlyingPawn to a MF59Ending pawn
+            );
+        }
+    );
 }
 
 split
 {
     // Trigger a split when missionComplete transitions from 2 to 3 (for most missions) or at the end of Kings or Faust.
-    return (current.missionComplete == 3 && old.missionComplete == 2) || vars.FaustSplit() || vars.KingsSplit();
+    return (
+        (current.missionComplete == 3 && old.missionComplete == 2) ||
+        vars.FaustSplit(current.levelSequencePhase, current.missionComplete, current.playerRef, current.controllerPawn) ||
+        vars.KingsSplit(current.levelSequencePhase, old.levelSequencePhase, current.missionComplete)
+    );
 }
 
 isLoading


### PR DESCRIPTION
Fixes `split()` not triggering at the ends of Kings in vanilla, and Faust in the Frontline 59 DLC.

Neither mission relies on the typical mission complete flag, but there are unique workarounds.

In Kings: the `missionComplete` flag never triggers but the `levelSequencePhase` transitions to `PostMissionCutscene`
In Faust: when the logo cutscene appears, the `WingmanPlayerController.Pawn` is swapped from the normal `FlyingPawn` to a bespoke `MF59Ending` pawn, but the `GameMaster.PlayerRef` remains the same.

Instead of muddying the logic in the `split()` function, I've added two callable functions under `init`, `KingsSplit()` and `FaustSplit()` to handle the checking. 

