### PR TITLE
Campaign reset functionality

### DIFF
--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -78,7 +78,10 @@ reset
     )
     ||
     // Campaign mode only
-    // Watches 
+    // Watches onMissionSequence and levelSequencePhase. When the player has progressed beyond difficulty selection (onMissionSequence), test to see if levelSequencePhase has changed as well.
+    // When starting a new campaign, behaviour is as follows: onMissionSequence changes from 0 --> 1. levelSequencePhase stays put at 0, this is because the campaign starting cutscene is not counted as a briefing.
+    // When resuming a campaign, behaviour is as follows: onMissionSequence changes from 0 --> 1. levelSequencePhase changes from 0 --> 1, this is because it transitions to a briefing for the relevent resumed mission.
+    // Reset only occurs when we satisfy the conditions for starting a new campaign.
     (
         current.onMissionSequence == 1 && old.onMissionSequence == 0
         &&

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -52,7 +52,7 @@ startup
         // Automatically starts timer on difficulty select.
         // Does not reset automatically
         // Automatically splits once at the end of each mission (only if you complete it)
-        settings.SetToolTip("Campaign", "For running full playthrough categories using campaign mode. Autostarts upon difficulty selection, and splits once at the end of each mission");
+        settings.SetToolTip("Campaign", "For running full playthrough categories using campaign mode. Autostarts upon difficulty selection, splits once at the end of each mission, and resets when starting a new campaign");
         settings.Add("CrashProtection", false, "Crash Protection", "Campaign");
             // Basic crash option. Stops the timer if the game is closed.
                 settings.SetToolTip("CrashProtection", "Pauses the timer if you have not progressed beyond difficulty selection. If your game crashes, your timer will be paused until you select 'Resume' to continue a campaign run.");

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -1,8 +1,8 @@
-// Version: 1.1.1
+// Version: 1.1.2
 // By NitrogenCynic (https://www.speedrun.com/users/NitrogenCynic) and Hilimii (https://www.speedrun.com/users/Hilimii)
 
 // Added in this version:
-    // Split detection for Faust and Kings
+    // Campaign reset functionality
 
 state("ProjectWingman-Win64-Shipping")
 {

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -76,6 +76,16 @@ reset
         &&
         settings["Mission"] == true
     )
+    ||
+    // Campaign mode only
+    // Watches 
+    (
+        current.onMissionSequence == 1 && old.onMissionSequence == 0
+        &&
+        current.levelSequencePhase == old.levelSequencePhase
+        &&
+        settings["Campaign"] == true
+    )
     ;
 }
 

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -1,8 +1,8 @@
-// Version: 1.2.0
+// Version: 1.3.0
 // By NitrogenCynic (https://www.speedrun.com/users/NitrogenCynic) and Hilimii (https://www.speedrun.com/users/Hilimii)
 
 // Added in this version:
-    // Split detection for Express Lane: Tunnel Run
+    // Auto reset functionality for Campaign mode
 
 state("ProjectWingman-Win64-Shipping")
 {

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -1,8 +1,8 @@
-// Version: 1.1.2
+// Version: 1.2.0
 // By NitrogenCynic (https://www.speedrun.com/users/NitrogenCynic) and Hilimii (https://www.speedrun.com/users/Hilimii)
 
 // Added in this version:
-    // Campaign reset functionality
+    // Split detection for Express Lane: Tunnel Run
 
 state("ProjectWingman-Win64-Shipping")
 {

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -66,9 +66,9 @@ startup
 
 reset
 {
-    // Reset timer when playerRef is dereferenced (goes from defined to undefined).
-    // Mission mode only.
     return
+    // Mission mode only.
+        // Reset timer when playerRef is dereferenced (goes from defined to undefined).
     (
         current.playerRef == 0
         &&
@@ -78,14 +78,20 @@ reset
     )
     ||
     // Campaign mode only
-    // Watches onMissionSequence and levelSequencePhase. When the player has progressed beyond difficulty selection (onMissionSequence), test to see if levelSequencePhase has changed as well.
-    // When starting a new campaign, behaviour is as follows: onMissionSequence changes from 0 --> 1. levelSequencePhase stays put at 0, this is because the campaign starting cutscene is not counted as a briefing.
-    // When resuming a campaign, behaviour is as follows: onMissionSequence changes from 0 --> 1. levelSequencePhase changes from 0 --> 1, this is because it transitions to a briefing for the relevent resumed mission.
-    // Reset only occurs when we satisfy the conditions for starting a new campaign.
+        // Watches onMissionSequence and levelSequencePhase. When the player has progressed beyond difficulty selection (onMissionSequence), test to see if levelSequencePhase has changed as well.
+        // When starting a new campaign, behaviour is as follows: onMissionSequence changes from 0 --> 1. levelSequencePhase stays put at 0, this is because the campaign starting cutscene is not counted as a briefing.
+        // When resuming a campaign, behaviour is as follows: onMissionSequence changes from 0 --> 1. levelSequencePhase changes from 0 --> 1, this is because it transitions to a briefing for the relevent resumed mission.
+        // Reset only occurs when we satisfy the conditions for starting a new campaign.
     (
         current.onMissionSequence == 1 && old.onMissionSequence == 0
         &&
         current.levelSequencePhase == old.levelSequencePhase
+        &&
+        ( // Checks if the level we're transitioning to is the first mission of either campaign. This stops levels like campaign_17 'No Respite' triggering a reset with a cutscene.
+            vars.GetLevelID() == "campaign_01"
+            ||
+            vars.GetLevelID() == "mf_01"
+        )
         &&
         settings["Campaign"] == true
     )
@@ -215,4 +221,12 @@ isLoading
     {
         return false;
     }
+}
+
+update
+{
+    // for bug testing
+    //print("levelSequencePhase: " + current.levelSequencePhase.ToString());
+    //print("onMissionSequence: " + current.onMissionSequence.ToString());
+    //print("level: " + vars.GetLevelID().ToString());
 }


### PR DESCRIPTION
I had a burst of inspiration and realised that campaign auto resets are much easier to execute then I previously thought.

The short of it:

Watch the value of `onMissionSequence `and when it changes from 0 to 1.
Also watch the value of `levelSequencePhase`. If it doesn't change at the same time as `onMissionSequence`, it means a new campaign has started, hence reset. If `levelSequencePhase `does change, it means the player has resumed a campaign, hence no reset.

Since `reset` triggers before `start` in the order of operations, it means that we can reset the timer and start it again to begin a new campaign on the same tick!

I've tested both vanilla and F59, both seem to work. If you can find any mistakes or bugs, lemme know!