### PR TITLE
IG Timer Update

### DIFF
--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -398,16 +398,18 @@ isLoading
             // Checks if the player is in mission by comparing intoLevel and playerRef and seeing if either is undefined. If so, pause.
             (
                 (
-                    (current.intoLevel == 0)
+                    (
+                        (current.intoLevel == 0)
+                        ||
+                        (current.playerRef == 0)
+                    )
                     ||
-                    (current.playerRef == 0)
-                )
-                ||
-                // Checks if the current mission has been completed (=3) and if the player is in mission. If so, pause.
-                (
-                    current.missionComplete == 3
-                    &&
-                    current.playerRef != 0
+                    // Checks if the current mission has been completed (=3) and if the player is in mission. If so, pause.
+                    (
+                        current.missionComplete == 3
+                        &&
+                        current.playerRef != 0
+                    )
                 )
                 // Checks if the IGT setting is on
                 &&

--- a/PW_Autosplitter.asl
+++ b/PW_Autosplitter.asl
@@ -3,8 +3,7 @@
 // By NitrogenCynic (https://www.speedrun.com/users/NitrogenCynic) and Hilimii (https://www.speedrun.com/users/Hilimii)
 
 // Added in this version:
-    // IGT Setting. Pauses when the player has no control over the plane. Mimics IGT timing for AC7.
-    // IgnoreTakeoffLanding setting. Applies the IGT setting to takeoff and landing sequences too.
+    // IGT Setting. Pauses when the player has no control over the plane, or when their time falls outside the remit of a IL run. Mimics IGT timing for AC7.
 //=====================================================================================================================================================================================================
 state("ProjectWingman-Win64-Shipping")
 // Defines pointers which are being read from game memory


### PR DESCRIPTION
I've added a setting, for the campaign mode, which pauses the timer unless the player is in mission. It functions quite closely to the way AC7 record their IGT. This is, of course, not legal for runs, but I'm adding it so people can play around with it.

I plan to test and then push this Wednesday next week. I know you're taking a hiatus, so only respond if you've got the time! It's a pretty small and watertight update (hopefully).

Conditions which cause the timer to pause when using IGT setting:

- Player pawn is not defined
- Player is not in level (IntoLevel = 0)
- Player has completed the mission (missionComplete =3), but hasn't skipped ahead yet.
- Player has paused the mission

How this works in practice:

- Timer is paused completely outside of missions in all other sequences. This includes briefings, debriefings, landings, takeoffs, menus, and hangars
- Timer is paused until 1.0s after the player presses 'start' to begin a mission
- Timer is immediately paused when the player resets a mission, and only resumed when the above bullet point becomes true
- Timer is paused when the player pauses in-game